### PR TITLE
Support for ES5 without having to deploy a transpiled version + updated ajv

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ Normalise errors from ajv to a simpler format.
 
 Takes ajv errors and returns a simpler object. Inspired by https://github.com/MauriceButler/jayschema-error-messages
 
+## Fork support ES5
+
+**This is a fork that ensure backward compatibility with ES5**, without providing a build folder. It basically makes it work with react-create-app, or anything that uses babel for building stuff.
+
+To be added in your package.json:
+
+`"ajv-error-messages": "git+ssh://git@github.com:StudyLink-fr/ajv-error-messages.git#v1.1.1",`
+
 ## Usage
 
 ```javascript

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function normaliseErrorMessages(errors) {
         {}
     );
 
-    return { fields };
+    return { fields: fields };
 }
 
 module.exports = normaliseErrorMessages;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/DivineGod/ajv-error-messages#readme",
   "devDependencies": {
-    "ajv": "^4.6.0",
+    "ajv": "^6.5.3",
     "tape": "^4.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ajv-error-messages",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Normalise AJV error messages",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ajv-error-messages",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Normalise AJV error messages",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Here is an example of what I did to use this lib with react-create-app, basically avoid special ES6 stuff because there is no transpilation (build directory)