### PR TITLE
fix: [BREAKING] Uprade AJV

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ results in
 ```
 {
     fields: {
-        'foo': ['Should be string']
+        '/foo': ['Must be string']
     }
 }
 ```

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 function normaliseErrorMessages(errors) {
-  console.log(errors);
   var fields = errors.reduce(function (acc, e) {
     if (e.instancePath.length && e.instancePath[0] === ".") {
       acc[e.instancePath.slice(1)] = [

--- a/index.js
+++ b/index.js
@@ -1,17 +1,17 @@
 function normaliseErrorMessages(errors) {
-    var fields = errors.reduce(
-        function (acc, e) {
-            if (e.dataPath.length && e.dataPath[0] === '.') {
-                acc[e.dataPath.slice(1)] = [e.message.toUpperCase()[0] + e.message.slice(1)];
-            } else {
-                acc[e.dataPath] = [e.message.toUpperCase()[0] + e.message.slice(1)];
-            }
-            return acc;
-        },
-        {}
-    );
+  console.log(errors);
+  var fields = errors.reduce(function (acc, e) {
+    if (e.instancePath.length && e.instancePath[0] === ".") {
+      acc[e.instancePath.slice(1)] = [
+        e.message.toUpperCase()[0] + e.message.slice(1),
+      ];
+    } else {
+      acc[e.instancePath] = [e.message.toUpperCase()[0] + e.message.slice(1)];
+    }
+    return acc;
+  }, {});
 
-    return { fields };
+  return { fields };
 }
 
 module.exports = normaliseErrorMessages;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,21 +5,28 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "ajv-error-messages",
       "version": "1.0.3",
       "license": "MIT",
       "devDependencies": {
-        "ajv": "^4.6.0",
+        "ajv": "^8.10.0",
         "tape": "^4.6.0"
       }
     },
     "node_modules/ajv": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
+      "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
       "dev": true,
       "dependencies": {
-        "co": "^4.6.0",
-        "json-stable-stringify": "^1.0.1"
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/balanced-match": {
@@ -49,16 +56,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true,
-      "engines": {
-        "iojs": ">= 1.0.0",
-        "node": ">= 0.12.0"
       }
     },
     "node_modules/concat-map": {
@@ -183,6 +180,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -360,19 +363,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
-      "dependencies": {
-        "jsonify": "~0.0.0"
-      }
-    },
-    "node_modules/jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
     },
     "node_modules/minimatch": {
@@ -464,10 +458,19 @@
       }
     },
     "node_modules/path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "node_modules/punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.3.1",
@@ -483,6 +486,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -581,6 +593,15 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -590,13 +611,15 @@
   },
   "dependencies": {
     "ajv": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
+      "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
       "dev": true,
       "requires": {
-        "co": "^4.6.0",
-        "json-stable-stringify": "^1.0.1"
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
       }
     },
     "balanced-match": {
@@ -624,12 +647,6 @@
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
       }
-    },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -725,6 +742,12 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "for-each": {
       "version": "0.3.3",
@@ -848,19 +871,10 @@
         "has-symbols": "^1.0.1"
       }
     },
-    "json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
-      "requires": {
-        "jsonify": "~0.0.0"
-      }
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+    "json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
     },
     "minimatch": {
@@ -928,9 +942,15 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
     "regexp.prototype.flags": {
@@ -942,6 +962,12 @@
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
       }
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true
     },
     "resolve": {
       "version": "1.17.0",
@@ -1020,6 +1046,15 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ajv-error-messages",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ajv-error-messages",
-      "version": "1.0.3",
+      "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
         "ajv": "^8.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ajv-error-messages",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "Normalise AJV error messages",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/DivineGod/ajv-error-messages#readme",
   "devDependencies": {
-    "ajv": "^4.6.0",
+    "ajv": "^8.10.0",
     "tape": "^4.6.0"
   }
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,82 +1,76 @@
-var test = require('tape');
-var normalise = require('../index');
-var SchemaValidator = require('ajv');
+var test = require("tape");
+var normalise = require("../index");
+var SchemaValidator = require("ajv");
 var schemaValidator = new SchemaValidator({ allErrors: true });
 
-test('normalise should exist', function (t) {
-    t.plan(1);
-    t.equal(typeof normalise, 'function', 'normalise is a function');
+test("normalise should exist", function (t) {
+  t.plan(1);
+  t.equal(typeof normalise, "function", "normalise is a function");
 });
 
-test('should normalise errors', function(t) {
-    t.plan(2);
+test("should normalise errors", function (t) {
+  t.plan(2);
 
-    var testSchema = {
-        description: 'test schema',
-        type: 'object',
-        required: ['foo', 'arrayThing'],
-        additionalProperties: false,
-        properties: {
-            foo: {
-                type: 'string',
-            },
-            arrayThing: {
-                type: 'array',
-                items: [
-                    { type: 'string', },
-                    { type: 'integer', },
-                ],
-                minItems: 2,
-                maxItems: 2,
-            },
-        },
-    };
-    var testData = {
-        foo: 1,
-        arrayThing: [123,'123',{}],
-    };
-    var expectedErrors = {
-        fields: {
-            foo: ['Should be string'],
-            arrayThing: ['Should NOT have more than 2 items'],
-            'arrayThing[0]': ['Should be string'],
-            'arrayThing[1]': ['Should be integer'],
-        },
-    };
-
-    var validator = schemaValidator.compile(testSchema);
-    var isValid = validator(testData);
-    var normalisedErrors = normalise(validator.errors);
-    t.notOk(isValid, 'validation failed');
-    t.deepEqual(normalisedErrors, expectedErrors, 'correctly normalised errors');
-});
-
-test('should work with root array', function(t) {
-    t.plan(2);
-
-    var testSchema = {
-        description: 'test schema',
-        type: 'array',
-        items: [
-            { type: 'string', },
-            { type: 'integer', },
-        ],
+  var testSchema = {
+    description: "test schema",
+    type: "object",
+    required: ["foo", "arrayThing"],
+    additionalProperties: false,
+    properties: {
+      foo: {
+        type: "string",
+      },
+      arrayThing: {
+        type: "array",
+        items: [{ type: "string" }, { type: "integer" }],
         minItems: 2,
         maxItems: 2,
-    };
-    var testData = [123,'123',{}];
+      },
+    },
+  };
+  var testData = {
+    foo: 1,
+    arrayThing: [123, "123", {}],
+  };
+  var expectedErrors = {
+    fields: {
+      "/foo": ["Must be string"],
+      "/arrayThing": ["Must NOT have more than 2 items"],
+      "/arrayThing/0": ["Must be string"],
+      "/arrayThing/1": ["Must be integer"],
+    },
+  };
 
-    var expectedErrors = {
-        fields: {
-            '': ['Should NOT have more than 2 items'],
-            '[0]': ['Should be string'],
-            '[1]': ['Should be integer'],
-        },
-    };
+  var validator = schemaValidator.compile(testSchema);
+  var isValid = validator(testData);
+  var normalisedErrors = normalise(validator.errors);
+  t.notOk(isValid, "validation failed");
+  t.deepEqual(normalisedErrors, expectedErrors, "correctly normalised errors");
+});
 
-    var validator = schemaValidator.compile(testSchema);
-    var isValid = validator(testData);
-    var normalisedErrors = normalise(validator.errors);
-    t.notOk(isValid, 'validation failed');
-    t.deepEqual(normalisedErrors, expectedErrors, 'correctly normalised errors');
+test("should work with root array", function (t) {
+  t.plan(2);
+
+  var testSchema = {
+    description: "test schema",
+    type: "array",
+    items: [{ type: "string" }, { type: "integer" }],
+    minItems: 2,
+    maxItems: 2,
+  };
+  var testData = [123, "123", {}];
+
+  var expectedErrors = {
+    fields: {
+      "": ["Must NOT have more than 2 items"],
+      "/0": ["Must be string"],
+      "/1": ["Must be integer"],
+    },
+  };
+
+  var validator = schemaValidator.compile(testSchema);
+  var isValid = validator(testData);
+  var normalisedErrors = normalise(validator.errors);
+  t.notOk(isValid, "validation failed");
+  t.deepEqual(normalisedErrors, expectedErrors, "correctly normalised errors");
 });


### PR DESCRIPTION
Fixes a security issue by upgrading AJv.

Breaking api change.
Error output formatting is changed.
Array indexing is now `/0` instead of `[0]`.
paths now start with `/` unless they're the root path which is still `` (empty string)